### PR TITLE
fix division by 0

### DIFF
--- a/code/track_1_kp_matching.py
+++ b/code/track_1_kp_matching.py
@@ -13,6 +13,10 @@ def get_ap(df, label_column, top_percentile=0.5):
     df = df.sort_values('score', ascending=False).head(top)
     # after selecting top percentile candidates, we set the score for the dummy kp to 1, to prevent it from increasing the precision.
     df.loc[df['key_point_id'] == "dummy_id", 'score'] = 0.99
+    # it seems like average_precision_score tries to divide by the sum of the labels
+    # which will fail in case all labels are 0
+    if (df[label_column] == 0).all():
+        return 0
     return average_precision_score(y_true=df[label_column], y_score=df["score"])
 
 def calc_mean_average_precision(df, label_column):


### PR DESCRIPTION
If all labels are 0, then the script will fail. average_precision_score tries to divide by the sum of the labels. Naturally it fails for 0. 

This should also fix https://github.com/IBM/KPA_2021_shared_task/issues/1

Modified example from https://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html results in NaN:
```python
import numpy as np
from sklearn.metrics import average_precision_score
y_true = np.array([0, 0, 0, 0])
y_scores = np.array([0.1, 0.4, 0.35, 0.8])
average_precision_score(y_true, y_scores)
```