### PR TITLE
Re-implement evaluation script

### DIFF
--- a/code/track_1_kp_matching.py
+++ b/code/track_1_kp_matching.py
@@ -1,86 +1,170 @@
-import sys
-import pandas as pd
-from sklearn.metrics import precision_recall_curve, average_precision_score, precision_score
-from matplotlib import pyplot
-import numpy as np
-import os
-import json
+from json import load
+from pathlib import Path
+from sys import argv
+from typing import List, Tuple
+
+from numpy import mean
+from pandas import DataFrame, read_csv
+from sklearn.metrics import average_precision_score
 
 
+def calculate_average_precision(df: DataFrame, label_column: str,
+                                top_percentile: float = 0.5):
+    """
+    Calculate average precision score for top-scores in the data frame
+    with respect to relaxed or strict ground truth labels.
+    """
+    top = int(len(df) * top_percentile)
+    df = df.sort_values("score", ascending=False).head(top)
+    return average_precision_score(
+        y_true=df[label_column],
+        y_score=df["score"]
+    )
 
-def get_ap(df, label_column, top_percentile=0.5):
-    top = int(len(df)*top_percentile)
-    df = df.sort_values('score', ascending=False).head(top)
-    # after selecting top percentile candidates, we set the score for the dummy kp to 1, to prevent it from increasing the precision.
-    df.loc[df['key_point_id'] == "dummy_id", 'score'] = 0.99
-    return average_precision_score(y_true=df[label_column], y_score=df["score"])
 
-def calc_mean_average_precision(df, label_column):
-    precisions = [get_ap(group, label_column) for _, group in df.groupby(["topic", "stance"])]
-    return np.mean(precisions)
+def calculate_mean_average_precision(df: DataFrame, label_column: str):
+    """
+    Calculate mean average precision score for top-scores
+    with respect to relaxed or strict ground truth labels
+    across argument key point pairs of same topic and stance.
+    """
+    precisions = [
+        calculate_average_precision(group, label_column)
+        for _, group in df.groupby(["topic", "stance"])
+    ]
+    return mean(precisions)
 
-def evaluate_predictions(merged_df):
-    mAP_strict = calc_mean_average_precision(merged_df, "label_strict")
-    mAP_relaxed = calc_mean_average_precision(merged_df, "label_relaxed")
-    print(f"mAP strict= {mAP_strict} ; mAP relaxed = {mAP_relaxed}")
 
-def load_kpm_data(gold_data_dir, subset):
-    arguments_file = os.path.join(gold_data_dir, f"arguments_{subset}.csv")
-    key_points_file = os.path.join(gold_data_dir, f"key_points_{subset}.csv")
-    labels_file = os.path.join(gold_data_dir, f"labels_{subset}.csv")
+def evaluate_predictions(merged_df: DataFrame):
+    """
+    Calculate mean average precision scores
+    for relaxed and strict ground truth labels
+    and print evaluation scores to console.
+    """
+    map_strict = calculate_mean_average_precision(merged_df, "label_strict")
+    map_relaxed = calculate_mean_average_precision(merged_df, "label_relaxed")
+    print(f"mAP strict= {map_strict} ; mAP relaxed = {map_relaxed}")
 
-    arguments_df = pd.read_csv(arguments_file)
-    key_points_df = pd.read_csv(key_points_file)
-    labels_file_df = pd.read_csv(labels_file)
+
+def load_kpm_data(
+        gold_data_dir: Path,
+        subset: str
+) -> Tuple[DataFrame, DataFrame, DataFrame]:
+    """
+    Load arguments, key points, and ground truth labels from
+    the data directory.
+    """
+
+    arguments_file = gold_data_dir / f"arguments_{subset}.csv"
+    key_points_file = gold_data_dir / f"key_points_{subset}.csv"
+    labels_file = gold_data_dir / f"labels_{subset}.csv"
+
+    arguments_df = read_csv(arguments_file)
+    key_points_df = read_csv(key_points_file)
+    labels_file_df = read_csv(labels_file)
 
     return arguments_df, key_points_df, labels_file_df
 
 
-def get_predictions(predictions_file, labels_df, arg_df):
-    arg_df = arg_df[["arg_id", "topic", "stance"]]
-    predictions_df = load_predictions(predictions_file)
-    #make sure each arg_id has a prediction
-    predictions_df = pd.merge(arg_df, predictions_df, how="left", on="arg_id")
+def load_predictions(predictions_file: Path) -> DataFrame:
+    """
+    Load data frame with argument key point matches and scores.
+    """
+    args: List[str] = []
+    kps: List[str] = []
+    scores: List[float] = []
+    with predictions_file.open("r") as file_in:
+        predictions = load(file_in)
+    for arg_id, kp_scores in predictions.items():
+        for kp_id, score in kp_scores.items():
+            args.append(arg_id)
+            kps.append(kp_id)
+            scores.append(score)
+    print(f"Loaded {len(args)} predictions "
+          f"for {len(predictions.items())} arguments.")
+    return DataFrame({
+        "arg_id": args,
+        "key_point_id": kps,
+        "score": scores
+    })
 
-    #handle arguements with no matching key point
-    predictions_df["key_point_id"] = predictions_df["key_point_id"].fillna("dummy_id")
-    predictions_df["score"] = predictions_df["score"].fillna(0)
 
-    #merge each argument with the gold labels
-    merged_df = pd.merge(predictions_df, labels_df, how="left", on=["arg_id", "key_point_id"])
+def merge_labels_with_predictions(
+        arg_df: DataFrame,
+        kp_df: DataFrame,
+        labels_df: DataFrame,
+        predictions_df: DataFrame
+) -> DataFrame:
+    """
+    Merge ground truth labels and predicted match scores
+    for all argument key point pairs.
+    Missing values are filled in as described in the task description.
+    """
 
-    merged_df.loc[merged_df['key_point_id'] == "dummy_id", 'label'] = 0
+    # Remove text columns. These are not needed for evaluation.
+    arg_df = arg_df.drop(columns=["argument"])
+    kp_df = kp_df.drop(columns=["key_point"])
+
+    # Create a data frame with all argument key point pairs
+    # of same topic and stance.
+    merged_df: DataFrame = arg_df.merge(kp_df, on=["topic", "stance"])
+
+    # Add ground truth labels.
+    # Note that we left-join here, because some pairs have undecided labels,
+    # i.e., >15% annotators yet <60% of them marked the pair as a match
+    # (as detailed in Bar-Haim et al., ACL-2020).
+    merged_df = merged_df.merge(
+        labels_df,
+        how="left",
+        on=["arg_id", "key_point_id"]
+    )
+    # Resolve undecided labels:
+    # For strict labels, fill with no match (0).
     merged_df["label_strict"] = merged_df["label"].fillna(0)
+    # For relaxed labels, fill with match (1).
     merged_df["label_relaxed"] = merged_df["label"].fillna(1)
+
+    # Add participant predictions.
+    # Note that we left-join here, because some pairs
+    # might not have been predicted by the participant.
+    merged_df = merged_df.merge(
+        predictions_df,
+        how="left",
+        on=["arg_id", "key_point_id"]
+    )
+    # Fill unpredicted labels, treat them as no match (0).
+    merged_df["score"] = merged_df["score"].fillna(0)
+    # Select best-scored key point per argument.
+    # Shuffle (with seed 42) to select a random key point in case of a tie.
+    merged_df = merged_df.groupby(by="arg_id") \
+        .apply(lambda df: df
+               .sample(frac=1, random_state=42)
+               .sort_values(by="score", ascending=False)
+               .head(1)) \
+        .reset_index(drop=True)
     return merged_df
 
 
-"""
-this method chooses the best key point for each argument
-and generates a dataframe with the matches and scores
-"""
-def load_predictions(predictions_dir):
-    arg =[]
-    kp = []
-    scores = []
-    with open(predictions_dir, "r") as f_in:
-        res = json.load(f_in)
-        for arg_id, kps in res.items():
-            best_kp = max(kps.items(), key=lambda x: x[1])
-            arg.append(arg_id)
-            kp.append(best_kp[0])
-            scores.append(best_kp[1])
-        print(f"loaded predictions for {len(arg)} arguments")
-        return pd.DataFrame({"arg_id" : arg, "key_point_id": kp, "score": scores})
+def main():
+    if len(argv) != 3:
+        print("You must specify two parameters for this scripts: "
+              "input data directory and the predictions file")
+        exit(1)
+
+    gold_data_dir = Path(argv[1])
+    predictions_file = Path(argv[2])
+
+    arg_df, kp_df, labels_df = load_kpm_data(gold_data_dir, subset="dev")
+    predictions_df = load_predictions(predictions_file)
+    merged_df = merge_labels_with_predictions(
+        arg_df,
+        kp_df,
+        labels_df,
+        predictions_df
+    )
+
+    evaluate_predictions(merged_df)
+
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("You must specify two parameters for this scripts: input data directory and the predictions file")
-    else:
-        gold_data_dir = sys.argv[1]
-        predictions_file = sys.argv[2]
-
-        arg_df, kp_df, labels_df = load_kpm_data(gold_data_dir, subset="dev")
-
-        merged_df = get_predictions(predictions_file, labels_df, arg_df)
-        evaluate_predictions(merged_df)
+    main()


### PR DESCRIPTION
The current evaluation script has some issues in specific conditions, especially if all labels are zero (#1, #2) or a predicitons file does not contain scores for each argument key point pair (#3, #4).
Second, when there is a tie in top-scored key points, the first key point is chosen. However, the task description states that the key point for an argument should be "randomly chosen in case of a tie".
Third, the implementation fills in dummy values that make it hard to understand the evaluation script and are not documented in the task description.
https://github.com/IBM/KPA_2021_shared_task/blob/eeaaf65fdcd2777be2485282786a917f6965c38b/code/track_1_kp_matching.py#L46

To address these issues, I have therefore re-implemented the evaluation script by following the task description as closely as possible. It would be great if you could take a look into the new implementation or otherwise fix the issues in the original scipt. I've tried my best to document all implementation details, but don't hesitate to ask in case of questions.

#### Impact on scores
I've checked the scores of the three public submissions with the original and new evaluation script.
Both strict and relaxed mAP are unchanged for 3J's BERT-Base submission.
Our term overlap baseline's scores change slightly.

| Submission | Evaluation | mAP strict | mAP relaxed |
|---|---|---:|---:|
| BERT-Base (3J) | original | 0.9330215172721863 | 0.9330215172721863 |
| BERT-Base (3J) | new | 0.9330215172721863 | 0.9330215172721863 |
| Term overlap (with preprocessing) | original | 0.6428707325554328 | 0.8017641012666208 |
| Term overlap (with preprocessing) | new | 0.6565378820089707 | 0.8094514423679504 |
| Term overlap | original | 0.5233282596542290 | 0.7022445394084025 |
| Term overlap | new | 0.5251743043326909 | 0.7020092150754788 |
